### PR TITLE
fix: migrate react-router to v8 and patch postcss advisory

### DIFF
--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -46,12 +46,12 @@
         "lucide-react": "^0.562.0",
         "next-themes": "^0.4.6",
         "qrcode.react": "^4.2.0",
-        "react": "^19.2.0",
+        "react": "^19.2.7",
         "react-day-picker": "^9.13.0",
-        "react-dom": "^19.2.0",
+        "react-dom": "^19.2.7",
         "react-hook-form": "^7.71.1",
         "react-resizable-panels": "^4.4.1",
-        "react-router-dom": "^7.12.0",
+        "react-router": "^8.3.0",
         "recharts": "^2.15.4",
         "sonner": "^2.0.7",
         "supertokens-auth-react": "^0.51.1",
@@ -5682,18 +5682,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -8271,9 +8264,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -8544,9 +8537,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8563,7 +8556,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8653,9 +8646,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -8684,16 +8677,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-hook-form": {
@@ -8800,41 +8793,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.17.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-smooth": {
@@ -9192,12 +9168,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -50,12 +50,12 @@
     "lucide-react": "^0.562.0",
     "next-themes": "^0.4.6",
     "qrcode.react": "^4.2.0",
-    "react": "^19.2.0",
+    "react": "^19.2.7",
     "react-day-picker": "^9.13.0",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.7",
     "react-hook-form": "^7.71.1",
     "react-resizable-panels": "^4.4.1",
-    "react-router-dom": "^7.12.0",
+    "react-router": "^8.3.0",
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
     "supertokens-auth-react": "^0.51.1",
@@ -87,7 +87,7 @@
     "vite-plugin-pwa": "^1.2.0"
   },
   "overrides": {
-    "postcss": "^8.4.38",
+    "postcss": "^8.5.18",
     "semver": "^7.5.2",
     "minimatch": "^10.2.1"
   }

--- a/client/web/src/components/AdminPortalButton.tsx
+++ b/client/web/src/components/AdminPortalButton.tsx
@@ -1,5 +1,5 @@
 import { ShieldCheck } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { useIsMobile } from "@/shared/hooks";
 import { useUserStore } from "@/shared/stores";

--- a/client/web/src/components/ErrorPage.tsx
+++ b/client/web/src/components/ErrorPage.tsx
@@ -1,9 +1,5 @@
 import { ArrowLeft, Home } from "lucide-react";
-import {
-  isRouteErrorResponse,
-  useNavigate,
-  useRouteError,
-} from "react-router-dom";
+import { isRouteErrorResponse, useNavigate, useRouteError } from "react-router";
 
 import { Button } from "@/components/ui/button";
 

--- a/client/web/src/layouts/AdminLayout.tsx
+++ b/client/web/src/layouts/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft } from "lucide-react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate } from "react-router";
 
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/pages/admin/_shared";

--- a/client/web/src/layouts/HackerLayout.tsx
+++ b/client/web/src/layouts/HackerLayout.tsx
@@ -1,6 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { Bell, CalendarDays, House, ScanLine, User } from "lucide-react";
-import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { NavLink, Outlet, useLocation } from "react-router";
 
 import {
   Sidebar,

--- a/client/web/src/main.tsx
+++ b/client/web/src/main.tsx
@@ -1,7 +1,7 @@
 import "./index.css";
 
 import ReactDOM from "react-dom/client";
-import { RouterProvider } from "react-router-dom";
+import { RouterProvider } from "react-router/dom";
 
 import { initSuperTokens } from "@/shared/auth";
 

--- a/client/web/src/pages/admin/_shared/AppSidebar.tsx
+++ b/client/web/src/pages/admin/_shared/AppSidebar.tsx
@@ -14,7 +14,7 @@ import {
   Users,
 } from "lucide-react";
 import * as React from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation } from "react-router";
 
 import { Separator } from "@/components/ui/separator";
 import {

--- a/client/web/src/pages/admin/_shared/NavSection.tsx
+++ b/client/web/src/pages/admin/_shared/NavSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { LucideIcon } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import {
   SidebarGroup,

--- a/client/web/src/pages/admin/_shared/NavUser.tsx
+++ b/client/web/src/pages/admin/_shared/NavUser.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronsUpDown, Eye, LogOut, ShieldCheck } from "lucide-react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import Session from "supertokens-auth-react/recipe/session";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";

--- a/client/web/src/pages/admin/_shared/grading/GradingPageLayout.tsx
+++ b/client/web/src/pages/admin/_shared/grading/GradingPageLayout.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/web/src/pages/admin/_shared/grading/useGradingKeyboardShortcuts.ts
+++ b/client/web/src/pages/admin/_shared/grading/useGradingKeyboardShortcuts.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 interface UseGradingKeyboardShortcutsOptions {
   disabled: boolean;

--- a/client/web/src/pages/admin/reviews/ReviewsPage.tsx
+++ b/client/web/src/pages/admin/reviews/ReviewsPage.tsx
@@ -1,6 +1,6 @@
 import { ClipboardPen, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import {

--- a/client/web/src/pages/admin/reviews/grading/GradingPage.tsx
+++ b/client/web/src/pages/admin/reviews/grading/GradingPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import {

--- a/client/web/src/pages/hacker/ApplyPage.tsx
+++ b/client/web/src/pages/hacker/ApplyPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import { ApplicationWizard } from "@/pages/hacker/apply/components/ApplicationWizard";

--- a/client/web/src/pages/hacker/DashboardPage.tsx
+++ b/client/web/src/pages/hacker/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router";
 import { signOut } from "supertokens-auth-react/recipe/session";
 
 import { Button } from "@/components/ui/button";

--- a/client/web/src/pages/hacker/StatusPage.tsx
+++ b/client/web/src/pages/hacker/StatusPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/client/web/src/pages/hacker/apply/components/ApplicationWizard.tsx
+++ b/client/web/src/pages/hacker/apply/components/ApplicationWizard.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";

--- a/client/web/src/pages/hacker/dashboard/DashboardPage.tsx
+++ b/client/web/src/pages/hacker/dashboard/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import { BookOpen, ChevronRight, Mail, MessageSquare } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 import { getRequest } from "@/shared/lib/api";
 import type {

--- a/client/web/src/pages/hacker/faq/FAQPage.tsx
+++ b/client/web/src/pages/hacker/faq/FAQPage.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import {
   Accordion,

--- a/client/web/src/pages/hacker/hacker-pack/HackerPackPage.tsx
+++ b/client/web/src/pages/hacker/hacker-pack/HackerPackPage.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft, ExternalLink } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/client/web/src/pages/hacker/profile/ProfilePage.tsx
+++ b/client/web/src/pages/hacker/profile/ProfilePage.tsx
@@ -8,7 +8,7 @@ import {
   Upload,
 } from "lucide-react";
 import { type ChangeEvent, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { signOut } from "supertokens-auth-react/recipe/session";
 

--- a/client/web/src/pages/hacker/status/StatusPage.tsx
+++ b/client/web/src/pages/hacker/status/StatusPage.tsx
@@ -1,7 +1,7 @@
 import { format, parseISO } from "date-fns";
 import { ChevronLeft, ChevronRight, Eye } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/web/src/pages/public/AuthCallbackPage.tsx
+++ b/client/web/src/pages/public/AuthCallbackPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import Session, { signOut } from "supertokens-auth-react/recipe/session";
 import { redirectToThirdPartyLogin } from "supertokens-auth-react/recipe/thirdparty";
 

--- a/client/web/src/pages/public/AuthOAuthCallbackPage.tsx
+++ b/client/web/src/pages/public/AuthOAuthCallbackPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { signInAndUp } from "supertokens-auth-react/recipe/thirdparty";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";

--- a/client/web/src/pages/public/AuthVerifyPage.tsx
+++ b/client/web/src/pages/public/AuthVerifyPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { consumeCode } from "supertokens-auth-react/recipe/passwordless";
 
 import { Button } from "@/components/ui/button";

--- a/client/web/src/pages/public/LoginPage.tsx
+++ b/client/web/src/pages/public/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { createCode } from "supertokens-auth-react/recipe/passwordless";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 import { redirectToThirdPartyLogin } from "supertokens-auth-react/recipe/thirdparty";

--- a/client/web/src/pages/superadmin/reviews/ReviewsPage.tsx
+++ b/client/web/src/pages/superadmin/reviews/ReviewsPage.tsx
@@ -12,7 +12,7 @@ import {
   TriangleAlert,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 
 import {

--- a/client/web/src/pages/superadmin/reviews/grading/GradingPage.tsx
+++ b/client/web/src/pages/superadmin/reviews/grading/GradingPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft } from "lucide-react";
 import { useCallback, useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { createBrowserRouter, Navigate, Outlet } from "react-router-dom";
+import { createBrowserRouter, Navigate, Outlet } from "react-router";
 
 import { ErrorPage } from "@/components/ErrorPage";
 import { PageLoader } from "@/components/PageLoader";

--- a/client/web/src/shared/auth/guards/RequireAdmin.tsx
+++ b/client/web/src/shared/auth/guards/RequireAdmin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/web/src/shared/auth/guards/RequireAuth.tsx
+++ b/client/web/src/shared/auth/guards/RequireAuth.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/web/src/shared/auth/guards/RequireSuperAdmin.tsx
+++ b/client/web/src/shared/auth/guards/RequireSuperAdmin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 
 import { Skeleton } from "@/components/ui/skeleton";


### PR DESCRIPTION
## Why

CI's audit gate (`npm audit --audit-level=high --omit=dev`) was failing on two advisories:

- **[GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2)** (high, CSRF) — affects `react-router >=7.12.0 <8.3.0`. Only fixed in v8.
- **[GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)** (high, path traversal in postcss source-map auto-loading) — affects `postcss <=8.5.17`.

## Changes

**`package.json`**
- `react-router-dom@^7.12.0` → `react-router@^8.3.0`. The `react-router-dom` package no longer exists in v8; it was only ever a re-export shim to smooth the v6→v7 upgrade.
- `react` / `react-dom` `^19.2.0` → `^19.2.7` — required, v8's peer range is `>=19.2.7` and the tree was resolving 19.2.4.
- `overrides.postcss` `^8.4.38` → `^8.5.18`. The override already existed but was loose enough to keep resolving 8.5.15; now resolves **8.5.23**.

**31 source files** — import specifier rewrite only, no API changes. Every export this app uses (`useNavigate`, `Navigate`, `Link`, `NavLink`, `Outlet`, `useLocation`, `useSearchParams`, `createBrowserRouter`, `RouterProvider`, `useRouteError`, `isRouteErrorResponse`) is exported from `react-router` root in v8.

The one non-mechanical change is **`src/main.tsx`**, which imports `RouterProvider` from **`react-router/dom`**, not the root. Verified against the published v8 package rather than the docs: `react-router/dom` exports only `RouterProvider`, `HydratedRouter`, and RSC APIs, and its `RouterProvider` is the root one pre-wired with `ReactDOM.flushSync` — exactly what v7's `react-router-dom` export was. This preserves existing behavior.

No `future.*` flags, loaders, actions, `meta()`, or `useMatches()` in this app, so none of v8's other breaking changes apply. Node 22 (CI) and 22.23.1 (Docker) both satisfy v8's `>=22.22.0` engine requirement.

## Verification

Run against a clean `npm ci`:

| Check | Result |
|---|---|
| `npm run format:check` | pass |
| `npm run lint` | 0 errors (1 pre-existing warning, `react-hook-form`'s `watch()`) |
| `npm run build` | pass |
| `npm audit --audit-level=high --omit=dev` | exit 0 |

Neither advisory appears in the full audit. Remaining findings are dev-only and pre-existing on `main` (`brace-expansion`, `fast-uri`, `js-yaml` via the eslint toolchain — excluded by `--omit=dev`; `esbuild` is low, below threshold).

**Runtime**, driven headlessly against the dev server — 15/15:
- Login page renders; all guarded routes (`/app`, `/app/status`, `/app/apply`, `/admin`, `/admin/all-applicants`, `/admin/sa/reviews`, `/admin/sa/walk-in-queue`) redirect to `/`
- Public auth routes (`/auth/verify`, `/auth/callback/google`) still match and don't fall through
- `*` catch-all renders `ErrorPage`; `navigate("/")` stays client-side; history back works
- No router-related console or page errors

Navigation-state semantics were also exercised directly against the installed v8 router core (9/9) — `navigate(path, { state })` delivery, and `navigate(path, { replace: true, state: null })` clearing state while emitting a new location key so a consuming effect re-runs once and terminates. That matters for the `justSubmitted` handling on #106's status page, which this PR doesn't contain.

## Not covered

Authenticated surfaces were not exercised in a browser — no session was available. Worth a signed-in click-through on the admin sidebar links, the grading pages' `useSearchParams` reads, and especially `NavUser`'s view-switch, which does `requestAnimationFrame(() => navigate(target))` to dodge a Radix `pointer-events` bug and is timing-sensitive against router internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
